### PR TITLE
CSVへ出力できるようにしました

### DIFF
--- a/lib/object_pascal_analyzer/cli.rb
+++ b/lib/object_pascal_analyzer/cli.rb
@@ -1,5 +1,6 @@
 require "object_pascal_analyzer"
 
+require 'csv'
 require 'json'
 require 'thor'
 
@@ -10,9 +11,30 @@ module ObjectPascalAnalyzer
       $stdout.puts "Show summary of #{path_to_dir}"
     end
 
+    CSV_HEADERS = [
+      :path, :class, :name,
+      :total_lines,
+      :empty_lines,
+      :comment_lines,
+      :max_depth,
+    ]
+
     desc 'csv PATH_TO_DIR', 'Show details in CSV'
-    def summary(path_to_dir)
-      $stdout.puts "Show details of #{path_to_dir} in CSV"
+    def csv(path_to_dir)
+      pascal_files = ObjectPascalAnalyzer.load(path_to_dir)
+      result = pascal_files.values.map do |f|
+        f.functions.map{|f| f.to_hash(full: true)}
+      end.flatten
+      options = {
+        write_headers: true,
+        headers: CSV_HEADERS,
+      }
+      output = CSV.generate("", options) do |csv|
+        result.each do |r|
+          csv << CSV_HEADERS.map{|h| r[h]}
+        end
+      end
+      $stdout.puts output
     end
 
     desc 'json PATH_TO_DIR', 'Show details in JSON'

--- a/lib/object_pascal_analyzer/pascal_class.rb
+++ b/lib/object_pascal_analyzer/pascal_class.rb
@@ -20,5 +20,9 @@ module ObjectPascalAnalyzer
         functions: functions.values.map(&:to_hash)
       }
     end
+
+    def function_array
+      functions.values
+    end
   end
 end

--- a/lib/object_pascal_analyzer/pascal_file.rb
+++ b/lib/object_pascal_analyzer/pascal_file.rb
@@ -20,5 +20,9 @@ module ObjectPascalAnalyzer
         classes: classes.values.map(&:to_hash)
       }
     end
+
+    def functions
+      classes.values.map(&:function_array).flatten
+    end
   end
 end

--- a/lib/object_pascal_analyzer/pascal_function.rb
+++ b/lib/object_pascal_analyzer/pascal_function.rb
@@ -41,14 +41,16 @@ module ObjectPascalAnalyzer
       end
     end
 
-    def to_hash
-      {
+    def to_hash(full: false)
+      r = {
         name: name,
         total_lines: total_lines,
         empty_lines: empty_lines,
         comment_lines: comment_lines,
         max_depth: max_depth,
       }
+      r.update(class: klass.name, path: klass.pascal_file.name) if full
+      return r
     end
   end
 end

--- a/spec/object_pascal_analyzer/to_hash_spec.rb
+++ b/spec/object_pascal_analyzer/to_hash_spec.rb
@@ -102,6 +102,40 @@ RSpec.describe ObjectPascalAnalyzer::PascalFile do
         expect(r.max_depth).to eq 2
       end
     end
+
+    it "is used with to_hash(full: true)" do
+      result = subject.functions.map{|f| f.to_hash(full: true)}
+      expected = [
+        {
+          path: "unit1.pas",
+          class: "TForm1",
+          name: "Button1Click",
+          total_lines: 10,
+          empty_lines: 2,
+          comment_lines: 3,
+          max_depth: 1,
+        },
+        {
+          path: "unit1.pas",
+          class: "TForm1",
+          name: "Input1Change",
+          total_lines: 40,
+          empty_lines: 2,
+          comment_lines: 10,
+          max_depth: 3,
+        },
+        {
+          path: "unit1.pas",
+          class: "THelper",
+          name: "run",
+          total_lines: 20,
+          empty_lines: 3,
+          comment_lines: 0,
+          max_depth: 2,
+        },
+      ]
+      expect(result).to eq expected
+    end
   end
 
 end

--- a/spec/object_pascal_analyzer/to_hash_spec.rb
+++ b/spec/object_pascal_analyzer/to_hash_spec.rb
@@ -72,13 +72,7 @@ RSpec.describe ObjectPascalAnalyzer::PascalFile do
 
   describe :functions do
     it do
-      expect(subject.classes.length).to eq 2
-      expect(subject.classes.values[0].functions.length).to eq 2
-      expect(subject.classes.values[1].functions.length).to eq 1
       result = subject.functions
-      result.each do |r|
-        p r
-      end
       expect(result.length).to eq 3
       result[0].tap do |r|
         expect(r.klass.pascal_file.name).to eq "unit1.pas"

--- a/spec/object_pascal_analyzer/to_hash_spec.rb
+++ b/spec/object_pascal_analyzer/to_hash_spec.rb
@@ -70,5 +70,44 @@ RSpec.describe ObjectPascalAnalyzer::PascalFile do
     end
   end
 
+  describe :functions do
+    it do
+      expect(subject.classes.length).to eq 2
+      expect(subject.classes.values[0].functions.length).to eq 2
+      expect(subject.classes.values[1].functions.length).to eq 1
+      result = subject.functions
+      result.each do |r|
+        p r
+      end
+      expect(result.length).to eq 3
+      result[0].tap do |r|
+        expect(r.klass.pascal_file.name).to eq "unit1.pas"
+        expect(r.klass.name).to eq "TForm1"
+        expect(r.name).to eq "Button1Click"
+        expect(r.total_lines).to eq 10
+        expect(r.empty_lines).to eq 2
+        expect(r.comment_lines).to eq 3
+        expect(r.max_depth).to eq 1
+      end
+      result[1].tap do |r|
+        expect(r.klass.pascal_file.name).to eq "unit1.pas"
+        expect(r.klass.name).to eq "TForm1"
+        expect(r.name).to eq "Input1Change"
+        expect(r.total_lines).to eq 40
+        expect(r.empty_lines).to eq 2
+        expect(r.comment_lines).to eq 10
+        expect(r.max_depth).to eq 3
+      end
+      result[2].tap do |r|
+        expect(r.klass.pascal_file.name).to eq "unit1.pas"
+        expect(r.klass.name).to eq "THelper"
+        expect(r.name).to eq "run"
+        expect(r.total_lines).to eq 20
+        expect(r.empty_lines).to eq 3
+        expect(r.comment_lines).to eq 0
+        expect(r.max_depth).to eq 2
+      end
+    end
+  end
 
 end

--- a/spec/object_pascal_analyzer/to_hash_spec.rb
+++ b/spec/object_pascal_analyzer/to_hash_spec.rb
@@ -1,34 +1,34 @@
 require 'object_pascal_analyzer/pascal_file'
 
 RSpec.describe ObjectPascalAnalyzer::PascalFile do
-  describe :to_hash do
-    subject do
-      ObjectPascalAnalyzer::PascalFile.new("unit1.pas").tap do |pf|
-        pf.class_by("TForm1").tap do |klass|
-          klass.function_by("Button1Click").tap do |f|
-            f.total_lines = 10
-            f.empty_lines = 2
-            f.comment_lines = 3
-            f.max_depth = 1
-          end
-          klass.function_by("Input1Change").tap do |f|
-            f.total_lines = 40
-            f.empty_lines = 2
-            f.comment_lines = 10
-            f.max_depth = 3
-          end
+  subject do
+    ObjectPascalAnalyzer::PascalFile.new("unit1.pas").tap do |pf|
+      pf.class_by("TForm1").tap do |klass|
+        klass.function_by("Button1Click").tap do |f|
+          f.total_lines = 10
+          f.empty_lines = 2
+          f.comment_lines = 3
+          f.max_depth = 1
         end
-        pf.class_by("THelper").tap do |klass|
-          klass.function_by("run").tap do |f|
-            f.total_lines = 20
-            f.empty_lines = 3
-            f.comment_lines = 0
-            f.max_depth = 2
-          end
+        klass.function_by("Input1Change").tap do |f|
+          f.total_lines = 40
+          f.empty_lines = 2
+          f.comment_lines = 10
+          f.max_depth = 3
+        end
+      end
+      pf.class_by("THelper").tap do |klass|
+        klass.function_by("run").tap do |f|
+          f.total_lines = 20
+          f.empty_lines = 3
+          f.comment_lines = 0
+          f.max_depth = 2
         end
       end
     end
+  end
 
+  describe :to_hash do
     it do
       expected = {
         path: "unit1.pas",


### PR DESCRIPTION
CSVを出力するための元のデータを作るために、 PascalFile#functions を実装し、 PascalFunction#to_hash を拡張しました。

## 実行結果

```
$ object_pascal_analyzer csv spec/jedi-jvcl/tests/restructured/examples/HID
ath,class,name,total_lines,empty_lines,comment_lines,max_depth
BasicDemo/Unit1.pas,TForm1,HidCtlDeviceChange,2,0,0,0
BasicDemo/Unit1.pas,TForm1,HidCtlEnumerate,4,0,0,0
CollectionDemo/Unit1.pas,TForm1,HidCtlDeviceChange,3,0,0,0
CollectionDemo/Unit1.pas,TForm1,EnumerateNodes,115,0,1,2
CollectionDemo/Unit1.pas,TForm1,HidCtlEnumerate,7,0,0,0
ReadWriteDemo/Unit1.pas,TForm1,HidCtlDeviceChange,27,5,0,3
ReadWriteDemo/Unit1.pas,TForm1,HidCtlEnumerate,12,0,0,1
ReadWriteDemo/Unit1.pas,TForm1,FormActivate,18,0,0,1
ReadWriteDemo/Unit1.pas,TForm1,FormDestroy,6,0,0,1
ReadWriteDemo/Unit1.pas,TForm1,InfoButtonClick,7,0,0,1
ReadWriteDemo/Unit1.pas,TForm1,DoRead,37,1,0,2
ReadWriteDemo/Unit1.pas,TForm1,DoWrite,41,5,0,2
ReadWriteDemo/Unit1.pas,TForm1,ReadButtonClick,1,0,0,0
ReadWriteDemo/Unit1.pas,TForm1,WriteButtonClick,1,0,0,0
ReadWriteDemo/Unit1.pas,TForm1,ListBox1Click,12,0,0,1
ReadWriteDemo/Unit2.pas,TInfoForm,FormCreate,17,0,0,0
ThreadDemo/MouseReader.pas,TForm1,HidCtlDeviceChange,38,0,7,2
ThreadDemo/MouseReader.pas,TMouseThread,HandleMouseData,6,0,2,0
ThreadDemo/MouseReader.pas,TMouseThread,Execute,18,0,5,1
ThreadDemo/MouseReader.pas,TMouseThread,Execute/Dummy,0,0,0,0
```
