### PR TITLE
Fix/invalid byte sequence in utf8

### DIFF
--- a/lib/object_pascal_analyzer.rb
+++ b/lib/object_pascal_analyzer.rb
@@ -10,7 +10,11 @@ module ObjectPascalAnalyzer
       base = Pathname.new(base_dir)
       Dir.glob(File.join(base_dir, "**/*.pas")).each.with_object({}) do |path, r|
         name = Pathname.new(path).relative_path_from(base).to_s
-        r[name] = PascalFileLoader.new(path, name).execute
+        begin
+          r[name] = PascalFileLoader.new(path, name).execute
+        rescue Exception => e
+          $stderr.puts("Failed to load %s because of %s" % [name, e.inspect])
+        end
       end
     end
   end

--- a/lib/object_pascal_analyzer.rb
+++ b/lib/object_pascal_analyzer.rb
@@ -13,7 +13,8 @@ module ObjectPascalAnalyzer
         begin
           r[name] = PascalFileLoader.new(path, name).execute
         rescue Exception => e
-          $stderr.puts("Failed to load %s because of %s" % [name, e.inspect])
+          $stderr.puts("Failed to load %s because of [%s] %s" % [name, e.class.name, e.inspect])
+          raise e
         end
       end
     end

--- a/lib/object_pascal_analyzer/pascal_file_loader.rb
+++ b/lib/object_pascal_analyzer/pascal_file_loader.rb
@@ -24,9 +24,10 @@ module ObjectPascalAnalyzer
       found_implementation = false
       # https://docs.ruby-lang.org/ja/2.3.0/class/NKF.html
       encode = NKF.guess(File.read(path))
+      # https://docs.ruby-lang.org/ja/2.3.0/method/IO/s/read.html
       # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
-      open(path, "r:utf-8:#{encode.to_s}") do |source_file|
-        source_file.each_line do |line|
+      source_text = File.read(path, mode: "r:utf-8:#{encode.to_s}")
+        source_text.lines.each do |line|
           if found_implementation
             process(line)
           else
@@ -35,7 +36,6 @@ module ObjectPascalAnalyzer
             end
           end
         end
-      end
       pascal_file
     end
 

--- a/lib/object_pascal_analyzer/pascal_file_loader.rb
+++ b/lib/object_pascal_analyzer/pascal_file_loader.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 require "object_pascal_analyzer"
 
+require 'nkf'
+
 require "object_pascal_analyzer/pascal_file"
 
 module ObjectPascalAnalyzer
@@ -20,7 +22,10 @@ module ObjectPascalAnalyzer
 
     def execute
       found_implementation = false
-      open(path) do |source_file|
+      # https://docs.ruby-lang.org/ja/2.3.0/class/NKF.html
+      encode = NKF.guess(File.read(path))
+      # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
+      open(path, "r:utf-8:#{encode.to_s}") do |source_file|
         source_file.each_line do |line|
           if found_implementation
             process(line)

--- a/lib/object_pascal_analyzer/pascal_file_loader.rb
+++ b/lib/object_pascal_analyzer/pascal_file_loader.rb
@@ -22,11 +22,7 @@ module ObjectPascalAnalyzer
 
     def execute
       found_implementation = false
-      # https://docs.ruby-lang.org/ja/2.3.0/class/NKF.html
-      encode = NKF.guess(File.read(path))
-      # https://docs.ruby-lang.org/ja/2.3.0/method/IO/s/read.html
-      # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
-      source_text = File.read(path, mode: "r:utf-8:#{encode.to_s}")
+      source_text = read_file(path)
       source_text.lines.each do |line|
         if found_implementation
           process(line)
@@ -37,6 +33,14 @@ module ObjectPascalAnalyzer
         end
       end
       pascal_file
+    end
+
+    def read_file(path)
+      # https://docs.ruby-lang.org/ja/2.3.0/class/NKF.html
+      encode = NKF.guess(File.read(path))
+      # https://docs.ruby-lang.org/ja/2.3.0/method/IO/s/read.html
+      # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
+      File.read(path, mode: "r:utf-8:#{encode.to_s}")
     end
 
     # Object pascal の識別子

--- a/lib/object_pascal_analyzer/pascal_file_loader.rb
+++ b/lib/object_pascal_analyzer/pascal_file_loader.rb
@@ -41,6 +41,9 @@ module ObjectPascalAnalyzer
       # https://docs.ruby-lang.org/ja/2.3.0/method/IO/s/read.html
       # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
       File.read(path, mode: "r:utf-8:#{encode.to_s}")
+    rescue EncodingError
+      # 変換不可能な不正な文字コードを含んでいる場合、それらを空白文字に置換した文字列を返します
+      File.read(path).encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "")
     end
 
     # Object pascal の識別子

--- a/lib/object_pascal_analyzer/pascal_file_loader.rb
+++ b/lib/object_pascal_analyzer/pascal_file_loader.rb
@@ -27,15 +27,15 @@ module ObjectPascalAnalyzer
       # https://docs.ruby-lang.org/ja/2.3.0/method/IO/s/read.html
       # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html
       source_text = File.read(path, mode: "r:utf-8:#{encode.to_s}")
-        source_text.lines.each do |line|
-          if found_implementation
-            process(line)
-          else
-            if IMPLEMENTATION_PATTERN =~ line
-              found_implementation = true
-            end
+      source_text.lines.each do |line|
+        if found_implementation
+          process(line)
+        else
+          if IMPLEMENTATION_PATTERN =~ line
+            found_implementation = true
           end
         end
+      end
       pascal_file
     end
 

--- a/spec/object_pascal_analyzer/pascal_file_loader_spec.rb
+++ b/spec/object_pascal_analyzer/pascal_file_loader_spec.rb
@@ -154,4 +154,16 @@ RSpec.describe ObjectPascalAnalyzer do
       it_behaves_like 'thread_demo_mouse_reader'
     end
   end
+
+  # JvSpecialProgress.pas includes some invalid character (byte sequences ).
+  File.expand_path("../../jedi-jvcl/tests/restructured/examples/JvSpecialProgress", __FILE__).tap do |path|
+    context path do
+      it do
+        expect {
+          ObjectPascalAnalyzer.load(path)
+        }.not_to raise_error
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
#6 への対応です。

- Shift_JISなどのUTF-8以外のソースコードを読み込めなかったので変換して読み込むように修正しました
- 不正な文字コードを含むソースコードの場合には、不正な文字を空白文字に変換して読み込むようにしました。