### PR TITLE
summaryコマンドに --number オプションを追加しました

### DIFF
--- a/lib/object_pascal_analyzer/cli.rb
+++ b/lib/object_pascal_analyzer/cli.rb
@@ -14,19 +14,22 @@ module ObjectPascalAnalyzer
     }
 
     desc 'summary PATH_TO_DIR', 'Show summary'
+    option :number, aliases: 'n', type: :numeric, default: 5
     def summary(path_to_dir)
       pascal_files = ObjectPascalAnalyzer.load(path_to_dir)
       functions = pascal_files.map(&:functions).flatten.map{|f| f.to_hash(full: true)}
 
+      num = options[:number].to_i
+
       result = [
         'Top 5 of the longest procedures or functions',
-        build_table(functions.sort(&sort_proc_for(SORT_KEYS[:total]))[0,5]),
+        build_table(functions.sort(&sort_proc_for(SORT_KEYS[:total]))[0,num]),
         '',
         'Top 5 of the deepest procedures or functions',
-        build_table(functions.sort(&sort_proc_for(SORT_KEYS[:depth]))[0,5]),
+        build_table(functions.sort(&sort_proc_for(SORT_KEYS[:depth]))[0,num]),
         '',
         'Top 5 of the most commented procedures or functions',
-        build_table(functions.sort(&sort_proc_for(SORT_KEYS[:comment]))[0,5]),
+        build_table(functions.sort(&sort_proc_for(SORT_KEYS[:comment]))[0,num]),
       ]
       output result.join("\n") + "\n"
     end

--- a/spec/object_pascal_analyzer/cli_spec.rb
+++ b/spec/object_pascal_analyzer/cli_spec.rb
@@ -27,8 +27,15 @@ RSpec.describe ObjectPascalAnalyzer::Cli do
   end
 
   describe :summary do
-    it do
+    it :default do
+      subject.options = {number: 5}
       expect(subject).to receive(:output).with(File.read(File.expand_path('../cli_spec/HID_summary.txt', __FILE__)))
+      subject.summary(File.expand_path('../../jedi-jvcl/tests/restructured/examples/HID', __FILE__))
+    end
+
+    it "only top 3" do
+      subject.options = {number: 3}
+      expect(subject).to receive(:output).with(File.read(File.expand_path('../cli_spec/HID_summary_top3.txt', __FILE__)))
       subject.summary(File.expand_path('../../jedi-jvcl/tests/restructured/examples/HID', __FILE__))
     end
   end

--- a/spec/object_pascal_analyzer/cli_spec/HID_summary_top3.txt
+++ b/spec/object_pascal_analyzer/cli_spec/HID_summary_top3.txt
@@ -1,0 +1,17 @@
+Top 5 of the longest procedures or functions
+Path                       Class  Name               Total Empty Comment Depth
+CollectionDemo/Unit1.pas   TForm1 EnumerateNodes       115     0       1     2
+ThreadDemo/MouseReader.pas TForm1 HidCtlDeviceChange    38     0       7     2
+ReadWriteDemo/Unit1.pas    TForm1 DoRead                35     0       0     2
+
+Top 5 of the deepest procedures or functions
+Path                       Class  Name               Total Empty Comment Depth
+ReadWriteDemo/Unit1.pas    TForm1 HidCtlDeviceChange    21     0       0     3
+CollectionDemo/Unit1.pas   TForm1 EnumerateNodes       115     0       1     2
+ThreadDemo/MouseReader.pas TForm1 HidCtlDeviceChange    38     0       7     2
+
+Top 5 of the most commented procedures or functions
+Path                       Class        Name               Total Empty Comment Depth
+ThreadDemo/MouseReader.pas TForm1       HidCtlDeviceChange    38     0       7     2
+ThreadDemo/MouseReader.pas TMouseThread Execute               18     0       5     1
+ThreadDemo/MouseReader.pas TMouseThread HandleMouseData        6     0       2     0


### PR DESCRIPTION
表示する件数を指定できるように `--number` オプションを追加しました

```
$ object_pascal_analyzer help summary
Usage:
  object_pascal_analyzer summary PATH_TO_DIR

Show summary
```
